### PR TITLE
Use a module, not a repo for rules_docker

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,12 +18,7 @@ bazel_dep(name = "rules_go", version = "0.57.0", repo_name = "io_bazel_rules_go"
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
 # Pinned to the discord fork of rules_docker
-http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "95ad0637a8c7cffe8c0205f18960c0a5a32735d86f517f9553878301d80e616b",
-    strip_prefix = "rules_docker-2bc402c5a49d0f702f89d4d7ab7ca570ba8e5102",
-    url = "https://github.com/discord/rules_docker/archive/2bc402c5a49d0f702f89d4d7ab7ca570ba8e5102.tar.gz",
-)
+bazel_dep(name = "io_bazel_rules_docker", version = "0.0.0")
 
 bazel_dep(name = "gazelle", version = "0.45.0", repo_name = "bazel_gazelle")
 


### PR DESCRIPTION
This should have been setup as a module, not as a repo, so it was causing misconfiguration issues when something tried to use both rules_docker and rules_k8s